### PR TITLE
WZ-2602 Added V2 constraint checkers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/hashicorp/go-version
+
+go 1.15


### PR DESCRIPTION
The only difference between the old checkers and the V2 checkers is that they skip checking the pre-release of the versions, it proved to be problematic as the constraints had no pre-release and the given versions did have, as a result the checkers always returned false.
For example: ">= 1.0.0, <= 1.20.0" "1.16.5-eks-9e69307" would return false.

So I added the `CheckV2` function which will be used in Trivy.